### PR TITLE
Upgrade guava from 28.2-jre to 29.0-jre

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -14,6 +14,6 @@ plugin.org.danilopianini.publish-on-central=0.2.3
 
 plugin.org.jlleitschuh.gradle.ktlint=9.0.0
 
-version.com.google.guava..guava=28.2-jre
+version.com.google.guava..guava=29.0-jre
 
 version.junit.junit=4.13


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.