### PR TITLE
Upgrade git-sensitive-semantic-versioning from 0.2.2 to 0.3.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,10 +14,6 @@ plugins {
     id("org.jlleitschuh.gradle.ktlint")
 }
 
-gitSemVer {
-    version = computeGitSemVer()
-}
-
 repositories {
     mavenCentral()
 }

--- a/versions.properties
+++ b/versions.properties
@@ -11,7 +11,7 @@ plugin.com.github.spotbugs=4.7.2
 
 plugin.io.gitlab.arturbosch.detekt=version.detekt
 
-plugin.org.danilopianini.git-sensitive-semantic-versioning=0.2.2
+plugin.org.danilopianini.git-sensitive-semantic-versioning=0.3.0
 
 plugin.org.danilopianini.javadoc.io-linker=0.1.4
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.