### PR TITLE
Upgrade detekt from 1.17.1 to 1.18.0

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -21,7 +21,7 @@ plugin.org.jlleitschuh.gradle.ktlint=9.2.1
 
 version.com.google.guava..guava=30.1.1-jre
 
-version.detekt=1.17.1
+version.detekt=1.18.0
 
 version.junit.junit=4.13.2
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.