### PR TITLE
Upgrade guava from 30.1.1-jre to 31.0-jre

### DIFF
--- a/versions.properties
+++ b/versions.properties
@@ -19,7 +19,7 @@ plugin.org.danilopianini.publish-on-central=0.5.0
 
 plugin.org.jlleitschuh.gradle.ktlint=10.2.0
 
-version.com.google.guava..guava=30.1.1-jre
+version.com.google.guava..guava=31.0-jre
 
 version.detekt=1.18.1
 


### PR DESCRIPTION
This update was prepared for you by UpGradle, at your service.