### PR TITLE
perf: replace LinkedList and Optionals with ArrayDeque and EnumMap

### DIFF
--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -29,8 +29,7 @@ import static java.lang.Math.nextUp;
 /**
  * @param <E> the type of objects stored in the quadtree
  */
-public final class FlexibleQuadTree<E> implements SpatialIndex<E>
-{
+public final class FlexibleQuadTree<E> implements SpatialIndex<E> {
 
     /**
      * Default maximum number of entries per node.
@@ -57,13 +56,23 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
     }
 
     private FlexibleQuadTree(
-            final double minx, final double maxx, final double miny, final double maxy,
-            final int elemPerQuad, final FlexibleQuadTree<E> rootNode, final FlexibleQuadTree<E> parentNode) {
+        final double minx,
+        final double maxx,
+        final double miny,
+        final double maxy,
+        final int elemPerQuad,
+        final FlexibleQuadTree<E> rootNode,
+        final FlexibleQuadTree<E> parentNode
+    ) {
         this(elemPerQuad, rootNode, parentNode);
         bounds = new Rectangle2D(minx, miny, maxx, maxy);
     }
 
-    private FlexibleQuadTree(final int elemPerQuad, final FlexibleQuadTree<E> rootNode, final FlexibleQuadTree<E> parentNode) {
+    private FlexibleQuadTree(
+        final int elemPerQuad,
+        final FlexibleQuadTree<E> rootNode,
+        final FlexibleQuadTree<E> parentNode
+    ) {
         if (elemPerQuad < 2) {
             throw new IllegalArgumentException("At least two elements per quadtree are required for this index to work properly");
         }
@@ -94,8 +103,12 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
     }
 
     private FlexibleQuadTree<E> create(
-            final double minx, final double maxx, final double miny, final double maxy,
-            final FlexibleQuadTree<E> father) {
+        final double minx,
+        final double maxx,
+        final double miny,
+        final double maxy,
+        final FlexibleQuadTree<E> father
+    ) {
         return new FlexibleQuadTree<>(minx, maxx, miny, maxy, getMaxElementsNumber(), root, father);
     }
 
@@ -512,11 +525,11 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
         @SuppressWarnings("UnstableApiUsage")
         public int hashCode() {
             return Hashing.murmur3_32_fixed().newHasher()
-                          .putDouble(x)
-                          .putDouble(y)
-                          .putInt(element.hashCode())
-                          .hash()
-                          .asInt();
+                .putDouble(x)
+                .putDouble(y)
+                .putInt(element.hashCode())
+                .hash()
+                .asInt();
         }
 
         public boolean isIn(final double sx, final double sy, final double fx, final double fy) {

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -16,6 +16,7 @@ import java.util.Deque;
 import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static java.lang.Math.ceil;
@@ -36,7 +37,7 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
      */
     public static final int DEFAULT_CAPACITY = 10;
     private static final long serialVersionUID = 0L;
-    private final EnumMap<Child, FlexibleQuadTree<E>> children;
+    private final Map<Child, FlexibleQuadTree<E>> children;
     private final Deque<QuadTreeEntry<E>> elements;
     private final int maxElements;
     private Rectangle2D bounds;

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -344,9 +344,11 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E> {
                      * Moved within the same quadrant.
                      */
                     cur.insertNode(e, fx, fy);
-                } else if (cur.parent == null
-                           || !cur.parent.contains(fx, fy)
-                           || !cur.swapMostStatic(e, fx, fy)) {
+                } else if (
+                    cur.parent == null
+                    || !cur.parent.contains(fx, fy)
+                    || !cur.swapMostStatic(e, fx, fy)
+                ) {
                     /*
                      * In case:
                      *  - we are the root
@@ -385,7 +387,12 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E> {
     }
 
     private void query(// NOPMD: False positive
-                       final double sx, final double sy, final double fx, final double fy, final List<E> results) {
+        final double sx,
+        final double sy,
+        final double fx,
+        final double fy,
+        final List<E> results
+    ) {
         assert !(bounds == null && !children.isEmpty());
         if (bounds == null || bounds.intersects(sx, sy, fx, fy)) {
             for (final QuadTreeEntry<E> entry : elements) {
@@ -393,7 +400,6 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E> {
                     results.add(entry.element);
                 }
             }
-
             // If there are no children, this will skip them.
             for (final FlexibleQuadTree<E> childOpt : children.values()) {
                 childOpt.query(sx, sy, fx, fy, results);

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -66,7 +66,7 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
         if (elemPerQuad < 2) {
             throw new IllegalArgumentException("At least two elements per quadtree are required for this index to work properly");
         }
-        elements = new ArrayDeque<>();
+        elements = new ArrayDeque<>(DEFAULT_CAPACITY);
         children = new EnumMap<>(Child.class);
         maxElements = elemPerQuad;
         parent = parentNode;


### PR DESCRIPTION
This pull request mainly does three things:

1. It swaps out the LinkedList implementation with an ArrayDeque. In most cases (i.e. adding and querying) this will improve performance as we only write or read an array. Moreover this allows to directly init with the default capacity which makes sure the array does not need to be grown. This is faster than the LinkedList which wraps every new entry. 
Only the remove and move calls might be slower, but even in the worst case, we only have 2 arraycopy calls on a size of default_capacity, which should be negligient. Also, I think that these operations are less often used compared to inserting elements and querying, but that is dependent on the use case.

2. Replace the Optional list of children with an EnumMap. There were a lot of list.get(c.ordinal()).get() calls in the code, which goes against the reason Optional is used (as the isPresent check is missing). Furthermore, the list init is quite hard to understand right now, because the Child enum is not linked to list size (4 is a magic value appearing there) and we always use c.ordinal() as the list index. For this, an EnumMap is much clearer. First of all, it directly reflects the Enum, makes the connection clear and does not need the verbose init of the current list. Removing the optional part was easy, and due to the already often missing isPresent checks I only needed to add one single null (in setChild()) in the entire codebase, and even that would be easy to remove. 

3. Thanks to the removal of the children absent optionals some methods have become much smaller and could be removed, like hasChildren() which is now equal to !children.isEmpty() or getChild(...) which is now children.get()