### PR TITLE
refactor: Use lombok to remove boilerplate code

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -13,6 +13,13 @@ repositories {
 
 dependencies {
     implementation(libs.guava)
+
+    compileOnly("org.projectlombok:lombok:1.18.22")
+    annotationProcessor("org.projectlombok:lombok:1.18.22")
+
+    testCompileOnly("org.projectlombok:lombok:1.18.22")
+    testAnnotationProcessor("org.projectlombok:lombok:1.18.22")
+
     testCompileOnly(libs.spotbugs.annotations)
     testImplementation(libs.junit4)
 }

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -29,8 +29,7 @@ import static java.lang.Math.nextUp;
 /**
  * @param <E> the type of objects stored in the quadtree
  */
-public final class FlexibleQuadTree<E> implements SpatialIndex<E>
-{
+public final class FlexibleQuadTree<E> implements SpatialIndex<E> {
 
     /**
      * Default maximum number of entries per node.
@@ -57,13 +56,23 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
     }
 
     private FlexibleQuadTree(
-            final double minx, final double maxx, final double miny, final double maxy,
-            final int elemPerQuad, final FlexibleQuadTree<E> rootNode, final FlexibleQuadTree<E> parentNode) {
+        final double minx,
+        final double maxx,
+        final double miny,
+        final double maxy,
+        final int elemPerQuad,
+        final FlexibleQuadTree<E> rootNode,
+        final FlexibleQuadTree<E> parentNode
+    ) {
         this(elemPerQuad, rootNode, parentNode);
         bounds = new Rectangle2D(minx, miny, maxx, maxy);
     }
 
-    private FlexibleQuadTree(final int elemPerQuad, final FlexibleQuadTree<E> rootNode, final FlexibleQuadTree<E> parentNode) {
+    private FlexibleQuadTree(
+        final int elemPerQuad,
+        final FlexibleQuadTree<E> rootNode,
+        final FlexibleQuadTree<E> parentNode
+    ) {
         if (elemPerQuad < 2) {
             throw new IllegalArgumentException("At least two elements per quadtree are required for this index to work properly");
         }
@@ -94,8 +103,12 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
     }
 
     private FlexibleQuadTree<E> create(
-            final double minx, final double maxx, final double miny, final double maxy,
-            final FlexibleQuadTree<E> father) {
+        final double minx,
+        final double maxx,
+        final double miny,
+        final double maxy,
+        final FlexibleQuadTree<E> father
+    ) {
         return new FlexibleQuadTree<>(minx, maxx, miny, maxy, getMaxElementsNumber(), root, father);
     }
 
@@ -512,11 +525,11 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
         @SuppressWarnings("UnstableApiUsage")
         public int hashCode() {
             return Hashing.murmur3_32_fixed().newHasher()
-                          .putDouble(x)
-                          .putDouble(y)
-                          .putInt(element.hashCode())
-                          .hash()
-                          .asInt();
+                .putDouble(x)
+                .putDouble(y)
+                .putInt(element.hashCode())
+                .hash()
+                .asInt();
         }
 
         public boolean isIn(final double sx, final double sy, final double fx, final double fy) {

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -16,6 +16,7 @@ import java.util.Deque;
 import java.util.EnumMap;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Map;
 import java.util.Objects;
 
 import static java.lang.Math.ceil;
@@ -36,7 +37,7 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
      */
     public static final int DEFAULT_CAPACITY = 10;
     private static final long serialVersionUID = 0L;
-    private final EnumMap<Child, FlexibleQuadTree<E>> children;
+    private final Map<Child, FlexibleQuadTree<E>> children;
     private final Deque<QuadTreeEntry<E>> elements;
     private final int maxElements;
     private Rectangle2D bounds;

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -29,7 +29,7 @@ import static java.lang.Math.nextUp;
 /**
  * @param <E> the type of objects stored in the quadtree
  */
-public final class FlexibleQuadTree<E> implements SpatialIndex<E> {
+public class FlexibleQuadTree<E> implements SpatialIndex<E> {
 
     /**
      * Default maximum number of entries per node.

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -6,6 +6,7 @@
  *******************************************************************************/
 package org.danilopianini.util;
 
+import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.Value;
 
@@ -377,11 +378,7 @@ public class FlexibleQuadTree<E> implements SpatialIndex<E> {
      */
     public List<E> query(final double x1, final double y1, final double x2, final double y2) {
         final List<E> result = new ArrayList<>();
-        final double sx = min(x1, x2);
-        final double sy = min(y1, y2);
-        final double fx = max(x1, x2);
-        final double fy = max(y1, y2);
-        root.query(sx, sy, fx, fy, result);
+        root.query(min(x1, x2), min(y1, y2), max(x1, x2), max(y1, y2), result);
         return result;
     }
 
@@ -515,8 +512,8 @@ public class FlexibleQuadTree<E> implements SpatialIndex<E> {
         double minY;
         double maxX;
         double maxY;
-        double centerX;
-        double centerY;
+        @EqualsAndHashCode.Exclude double centerX;
+        @EqualsAndHashCode.Exclude double centerY;
 
         Rectangle2D(final double sx, final double sy, final double fx, final double fy) {
             minX = min(sx, fx);

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -344,9 +344,11 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E> {
                      * Moved within the same quadrant.
                      */
                     cur.insertNode(e, fx, fy);
-                } else if (cur.parent == null
-                           || !cur.parent.contains(fx, fy)
-                           || !cur.swapMostStatic(e, fx, fy)) {
+                } else if (
+                    cur.parent == null
+                    || !cur.parent.contains(fx, fy)
+                    || !cur.swapMostStatic(e, fx, fy)
+                ) {
                     /*
                      * In case:
                      *  - we are the root
@@ -385,7 +387,12 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E> {
     }
 
     private void query(// NOPMD: False positive
-                       final double sx, final double sy, final double fx, final double fy, final List<E> results) {
+        final double sx,
+        final double sy,
+        final double fx,
+        final double fy,
+        final List<E> results
+    ) {
         assert !(bounds == null && !children.isEmpty());
         if (bounds == null || bounds.intersects(sx, sy, fx, fy)) {
             for (final QuadTreeEntry<E> entry : elements) {
@@ -393,7 +400,6 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E> {
                     results.add(entry.element);
                 }
             }
-
             // If there are no children, this will skip them.
             for (final FlexibleQuadTree<E> childOpt : children.values()) {
                 childOpt.query(sx, sy, fx, fy, results);

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -13,6 +13,7 @@ import javax.annotation.Nonnull;
 import java.io.Serializable;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Deque;
 import java.util.EnumMap;
 import java.util.Iterator;
@@ -467,6 +468,7 @@ public class FlexibleQuadTree<E> implements SpatialIndex<E> {
 
     private boolean swapMostStatic(final E e, final double fx, final double fy) {
         assert parent != null : "Tried to swap on a null parent.";
+
         final Iterator<QuadTreeEntry<E>> iterator = parent.elements.descendingIterator();
         while (iterator.hasNext()) {
             final QuadTreeEntry<E> target = iterator.next();
@@ -513,24 +515,20 @@ public class FlexibleQuadTree<E> implements SpatialIndex<E> {
         double minY;
         double maxX;
         double maxY;
+        double centerX;
+        double centerY;
 
         Rectangle2D(final double sx, final double sy, final double fx, final double fy) {
             minX = min(sx, fx);
             minY = min(sy, fy);
             maxX = max(sx, fx);
             maxY = max(sy, fy);
+            centerX = minX + (maxX - minX) / 2;
+            centerY = minY + (maxY - minY) / 2;
         }
 
         public boolean contains(final double x, final double y) {
             return x >= minX && y >= minY && x < maxX && y < maxY;
-        }
-
-        public double getCenterX() {
-            return minX + (maxX - minX) / 2;
-        }
-
-        public double getCenterY() {
-            return minY + (maxY - minY) / 2;
         }
 
         public boolean intersects(final double sx, final double sy, final double fx, final double fy) {

--- a/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
+++ b/src/main/java/org/danilopianini/util/FlexibleQuadTree.java
@@ -66,7 +66,7 @@ public final class FlexibleQuadTree<E> implements SpatialIndex<E>
         if (elemPerQuad < 2) {
             throw new IllegalArgumentException("At least two elements per quadtree are required for this index to work properly");
         }
-        elements = new ArrayDeque<>();
+        elements = new ArrayDeque<>(DEFAULT_CAPACITY);
         children = new EnumMap<>(Child.class);
         maxElements = elemPerQuad;
         parent = parentNode;


### PR DESCRIPTION
This PR is aimed at removing all the boilerplate code from the inner static classes by utilizing lombok.
The total code size is reduced by about 10% and is now (in my opinion) much more readable. 

This also removes the "murmur" hashing algorithm, as I did not see the reason to specifically use that and it is marked as unstable. Value generates its own hashing implementation.

I have also reordered the constructors from least arguments to most and inlined some local variables that were only used once.

Moreover, centerX and centerY are now distinct variables in rectangle so that the calculations are only done once because it seemed to me as if they are called quite often.

Furthermore, I have removed the final modifier from the class in case someone wants to extend it.